### PR TITLE
Replace mason nvim dap with manual download

### DIFF
--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -1,9 +1,3 @@
-require('mason').setup({
-  log_level = vim.log.levels.DEBUG
-})
-require('mason-nvim-dap').setup({
-  ensure_installed = { 'js', 'node2', 'chrome', 'firefox' },
-})
 require("dap-vscode-js").setup({
   -- node_path = "node", -- Path of node executable. Defaults to $NODE_PATH, and then "node"
   -- debugger_path = vim.fn.resolve(vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js"),

--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -15,6 +15,7 @@ require("dap-vscode-js").setup({
   -- log_file_level = false -- Logging level for output to file. Set to false to disable file logging.
   -- log_console_level = vim.log.levels.ERROR -- Logging level for output to console. Set to false to disable console output.
 })
+require("dapui").setup()
 
 local js_based_languages = { "typescript", "javascript", "typescriptreact", "javascriptreact" };
 for _, language in ipairs(js_based_languages) do
@@ -55,4 +56,20 @@ dap_vscode.load_launchjs(nil, {
 
 vim.keymap.set('n', '<Leader>db', ':lua require"dap".toggle_breakpoint()<CR>')
 vim.keymap.set('n', '<Leader>dc', ':lua require"dap".continue()<CR>')
+vim.keymap.set('n', '<Leader>do', ':lua require"dap".step_over()<CR>')
+vim.keymap.set('n', '<Leader>di', ':lua require"dap".step_into()<CR>')
+vim.keymap.set('n', '<Leader>dr', ':lua require"dap".repl.open()<CR>')
 
+local dap, dapui = require("dap"), require("dapui")
+dap.listeners.before.attach.dapui_config = function()
+  dapui.open()
+end
+dap.listeners.before.launch.dapui_config = function()
+  dapui.open()
+end
+dap.listeners.before.event_terminated.dapui_config = function()
+  dapui.close()
+end
+dap.listeners.before.event_exited.dapui_config = function()
+  dapui.close()
+end

--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -4,7 +4,8 @@ require("dap-vscode-js").setup({
   debugger_path = vim.fn.resolve(vim.fn.stdpath("data") .. "/lazy/vscode-js-debug/"), -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
   -- debugger_cmd = { "js-debug-adapter" }, -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
   -- debugger_cmd = { vim.fn.resolve(vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js") }, -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
-  adapters = { 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost', 'chrome' }, -- which adapters to register in nvim-dap
+  -- adapters = { 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost', 'chrome' }, -- which adapters to register in nvim-dap
+  adapters = { 'pwa-node', 'pwa-chrome' }, -- which adapters to register in nvim-dap
   -- log_file_path = "(stdpath cache)/dap_vscode_js.log" -- Path for file logging
   -- log_file_level = false -- Logging level for output to file. Set to false to disable file logging.
   -- log_console_level = vim.log.levels.ERROR -- Logging level for output to console. Set to false to disable console output.
@@ -68,11 +69,8 @@ end
 local dap_vscode = require('dap.ext.vscode')
 dap_vscode.json_decode = require('overseer.json').decode
 dap_vscode.load_launchjs(nil, {
-  ['chrome'] = js_based_languages,
-  ['node'] = js_based_languages,
   ['pwa-node'] = js_based_languages,
   ['pwa-chrome'] = js_based_languages,
-  ['node-terminal'] = js_based_languages,
 })
 
 vim.keymap.set('n', '<Leader>db', ':lua require"dap".toggle_breakpoint()<CR>')

--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -35,7 +35,21 @@ for _, language in ipairs(js_based_languages) do
       --processId = require'dap.utils'.pick_process, -- seems not to be required, auto-attach happens successfully in all the contexts I've tried
       cwd = "${workspaceFolder}",
       --cwd = vim.fn.getcwd(), -- alternate way of getting workspace folder which may only do the same as "${workspaceFolder}" but while I'm paranoid about getting this working I jjj
-      port = 9230,
+      port = function()
+        local co = coroutine.running()
+        return coroutine.create(function()
+          vim.ui.input({
+            prompt = "Enter node inspector port: ",
+            default = "9229",
+          }, function(port)
+            if port == nil or port == "" then
+              return
+            else
+              coroutine.resume(co, port)
+            end
+          end)
+        end)
+      end,
       sourceMaps = true,
     },
     -- Divider for the launch.json derived configs

--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -31,7 +31,7 @@ for _, language in ipairs(js_based_languages) do
     {
       type = "pwa-node",
       request = "attach",
-      name = "Attach",
+      name = "Attach to local server:?",
       --processId = require'dap.utils'.pick_process, -- seems not to be required, auto-attach happens successfully in all the contexts I've tried
       cwd = "${workspaceFolder}",
       --cwd = vim.fn.getcwd(), -- alternate way of getting workspace folder which may only do the same as "${workspaceFolder}" but while I'm paranoid about getting this working I jjj
@@ -55,10 +55,10 @@ for _, language in ipairs(js_based_languages) do
     {
       type = "pwa-chrome",
       request = "attach",
-      name = "Debug Chrome",
-      address = "0.0.0.0",
+      name = "Attach to docker host remote chrome:9222",
+      address = "host.docker.internal",
       port = "9222",
-      webRoot = vim.fn.getcwd(),
+      webRoot = "${workspaceFolder}",
       protocol = "inspector",
       sourceMaps = true,
       userDataDir = false,

--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -52,6 +52,17 @@ for _, language in ipairs(js_based_languages) do
       end,
       sourceMaps = true,
     },
+    {
+      type = "pwa-chrome",
+      request = "attach",
+      name = "Debug Chrome",
+      address = "0.0.0.0",
+      port = "9222",
+      webRoot = vim.fn.getcwd(),
+      protocol = "inspector",
+      sourceMaps = true,
+      userDataDir = false,
+    },
     -- Divider for the launch.json derived configs
     {
       name = '----- launch.json configs (if available) -----',

--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -32,8 +32,10 @@ for _, language in ipairs(js_based_languages) do
       type = "pwa-node",
       request = "attach",
       name = "Attach",
-      processId = require'dap.utils'.pick_process,
+      --processId = require'dap.utils'.pick_process, -- seems not to be required, auto-attach happens successfully in all the contexts I've tried
       cwd = "${workspaceFolder}",
+      --cwd = vim.fn.getcwd(), -- alternate way of getting workspace folder which may only do the same as "${workspaceFolder}" but while I'm paranoid about getting this working I jjj
+      port = 9230,
       sourceMaps = true,
     },
     -- Divider for the launch.json derived configs

--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -4,53 +4,37 @@ require('mason').setup({
 require('mason-nvim-dap').setup({
   ensure_installed = { 'js', 'node2', 'chrome', 'firefox' },
 })
+require("dap-vscode-js").setup({
+  -- node_path = "node", -- Path of node executable. Defaults to $NODE_PATH, and then "node"
+  -- debugger_path = vim.fn.resolve(vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js"),
+  debugger_path = vim.fn.resolve(vim.fn.stdpath("data") .. "/lazy/vscode-js-debug/"), -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
+  -- debugger_cmd = { "js-debug-adapter" }, -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
+  -- debugger_cmd = { vim.fn.resolve(vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js") }, -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
+  adapters = { 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost' }, -- which adapters to register in nvim-dap
+  -- log_file_path = "(stdpath cache)/dap_vscode_js.log" -- Path for file logging
+  -- log_file_level = false -- Logging level for output to file. Set to false to disable file logging.
+  -- log_console_level = vim.log.levels.ERROR -- Logging level for output to console. Set to false to disable console output.
+})
+
+for _, language in ipairs({ "typescript", "javascript", "typescriptreact", "javascriptreact" }) do
+  require("dap").configurations[language] = {
+    {
+      type = "pwa-node",
+      request = "launch",
+      name = "Launch file",
+      program = "${file}",
+      cwd = "${workspaceFolder}",
+    },
+    {
+      type = "pwa-node",
+      request = "attach",
+      name = "Attach",
+      processId = require'dap.utils'.pick_process,
+      cwd = "${workspaceFolder}",
+    }
+  }
+end
 
 vim.keymap.set('n', '<Leader>db', ':lua require"dap".toggle_breakpoint()<CR>')
 vim.keymap.set('n', '<Leader>dc', ':lua require"dap".continue()<CR>')
-
-local dap = require('dap')
-
-dap.adapters['pwa-node'] = {
-  type = "server",
-  host = "localhost",
-  port = "${port}",
-  executable = {
-    command = "node",
-    args = {vim.fn.resolve(vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js"), "${port}"},
-  }
-}
-dap.adapters.node2 = {
-  type = 'executable',
-  command = 'node',
-  args = {vim.fn.resolve(vim.fn.stdpath("data") .. "/mason/packages/node-debug2-adapter/out/src/nodeDebug.js")},
-}
-
-dap.configurations.typescript = {
-  {
-		name = 'Node2: Launch';
-		type = 'node2';
-		request = 'launch';
-		program = '${file}';
-		cwd = vim.fn.getcwd();
-		sourceMaps = true;
-		protocol = 'inspector';
-		console = 'integratedTerminal';
-  },
-  {
-    type = "pwa-node",
-    request = "launch",
-    name = "Launch file",
-    program = "${file}",
-    cwd = "${workspaceFolder}",
-		sourceMaps = true,
-  },
-  {
-    type = "pwa-node",
-    request = "attach",
-    name = "Attach",
-    processId = require'dap.utils'.pick_process,
-    cwd = "${workspaceFolder}",
-		sourceMaps = true,
-  }
-}
 

--- a/lua/jslog/plugins/dap.lua
+++ b/lua/jslog/plugins/dap.lua
@@ -10,13 +10,14 @@ require("dap-vscode-js").setup({
   debugger_path = vim.fn.resolve(vim.fn.stdpath("data") .. "/lazy/vscode-js-debug/"), -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
   -- debugger_cmd = { "js-debug-adapter" }, -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
   -- debugger_cmd = { vim.fn.resolve(vim.fn.stdpath("data") .. "/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js") }, -- Command to use to launch the debug server. Takes precedence over `node_path` and `debugger_path`.
-  adapters = { 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost' }, -- which adapters to register in nvim-dap
+  adapters = { 'pwa-node', 'pwa-chrome', 'pwa-msedge', 'node-terminal', 'pwa-extensionHost', 'chrome' }, -- which adapters to register in nvim-dap
   -- log_file_path = "(stdpath cache)/dap_vscode_js.log" -- Path for file logging
   -- log_file_level = false -- Logging level for output to file. Set to false to disable file logging.
   -- log_console_level = vim.log.levels.ERROR -- Logging level for output to console. Set to false to disable console output.
 })
 
-for _, language in ipairs({ "typescript", "javascript", "typescriptreact", "javascriptreact" }) do
+local js_based_languages = { "typescript", "javascript", "typescriptreact", "javascriptreact" };
+for _, language in ipairs(js_based_languages) do
   require("dap").configurations[language] = {
     {
       type = "pwa-node",
@@ -24,6 +25,7 @@ for _, language in ipairs({ "typescript", "javascript", "typescriptreact", "java
       name = "Launch file",
       program = "${file}",
       cwd = "${workspaceFolder}",
+      sourceMaps = true,
     },
     {
       type = "pwa-node",
@@ -31,9 +33,25 @@ for _, language in ipairs({ "typescript", "javascript", "typescriptreact", "java
       name = "Attach",
       processId = require'dap.utils'.pick_process,
       cwd = "${workspaceFolder}",
-    }
+      sourceMaps = true,
+    },
+    -- Divider for the launch.json derived configs
+    {
+      name = '----- launch.json configs (if available) -----',
+      type = '',
+      request = 'launch',
+    },
   }
 end
+local dap_vscode = require('dap.ext.vscode')
+dap_vscode.json_decode = require('overseer.json').decode
+dap_vscode.load_launchjs(nil, {
+  ['chrome'] = js_based_languages,
+  ['node'] = js_based_languages,
+  ['pwa-node'] = js_based_languages,
+  ['pwa-chrome'] = js_based_languages,
+  ['node-terminal'] = js_based_languages,
+})
 
 vim.keymap.set('n', '<Leader>db', ':lua require"dap".toggle_breakpoint()<CR>')
 vim.keymap.set('n', '<Leader>dc', ':lua require"dap".continue()<CR>')

--- a/lua/jslog/plugins/install.lua
+++ b/lua/jslog/plugins/install.lua
@@ -35,12 +35,24 @@ require('lazy').setup({
   -- END LSP RELATED PLUGINS --
   'github/copilot.vim',
   'github/copilot.vim',
+  -- START DAP RELATED PLUGINS --
+  'mfussenegger/nvim-dap',
+  {
+    'microsoft/vscode-js-debug',
+    dependencies = {'mfussenegger/nvim-dap',},
+    build = 'npm install --legacy-peer-deps && npx gulp vsDebugServerBundle && mv dist out'
+  },
+  {
+    'mxsdev/nvim-dap-vscode-js',
+    dependencies = {'mfussenegger/nvim-dap', 'microsoft/vscode-js-debug'}
+  },
+  {
+    'jay-babu/mason-nvim-dap.nvim',
+    dependencies = {'williamboman/mason.nvim', 'mfussenegger/nvim-dap', 'mxsdev/nvim-dap-vscode-js'}
+  },
   {
     'rcarriga/nvim-dap-ui',
     dependencies = {'mfussenegger/nvim-dap', 'nvim-neotest/nvim-nio'}
   },
-  {
-    'jay-babu/mason-nvim-dap.nvim',
-    dependencies = {'rcarriga/nvim-dap-ui','williamboman/mason.nvim'}
-  }
+  -- END DAP RELATED PLUGINS --
 })

--- a/lua/jslog/plugins/install.lua
+++ b/lua/jslog/plugins/install.lua
@@ -38,13 +38,16 @@ require('lazy').setup({
   -- START DAP RELATED PLUGINS --
   'mfussenegger/nvim-dap',
   {
+    'stevearc/overseer.nvim',
+    opts = {},
+  },
+  {
     'microsoft/vscode-js-debug',
-    dependencies = {'mfussenegger/nvim-dap',},
     build = 'npm install --legacy-peer-deps && npx gulp vsDebugServerBundle && mv dist out'
   },
   {
     'mxsdev/nvim-dap-vscode-js',
-    dependencies = {'mfussenegger/nvim-dap', 'microsoft/vscode-js-debug'}
+    dependencies = {'mfussenegger/nvim-dap', 'microsoft/vscode-js-debug', 'stevearc/overseer.nvim' }
   },
   {
     'jay-babu/mason-nvim-dap.nvim',

--- a/lua/jslog/plugins/install.lua
+++ b/lua/jslog/plugins/install.lua
@@ -50,10 +50,6 @@ require('lazy').setup({
     dependencies = {'mfussenegger/nvim-dap', 'microsoft/vscode-js-debug', 'stevearc/overseer.nvim' }
   },
   {
-    'jay-babu/mason-nvim-dap.nvim',
-    dependencies = {'williamboman/mason.nvim', 'mfussenegger/nvim-dap', 'mxsdev/nvim-dap-vscode-js'}
-  },
-  {
     'rcarriga/nvim-dap-ui', tag = 'v4.0.0',
     dependencies = {'mfussenegger/nvim-dap', 'nvim-neotest/nvim-nio'}
   },

--- a/lua/jslog/plugins/install.lua
+++ b/lua/jslog/plugins/install.lua
@@ -36,17 +36,17 @@ require('lazy').setup({
   'github/copilot.vim',
   'github/copilot.vim',
   -- START DAP RELATED PLUGINS --
-  'mfussenegger/nvim-dap',
+  'mfussenegger/nvim-dap', tag = '0.7.0',
   {
-    'stevearc/overseer.nvim',
+    'stevearc/overseer.nvim', tag = 'v1.3.1',
     opts = {},
   },
   {
-    'microsoft/vscode-js-debug',
+    'microsoft/vscode-js-debug', tag = 'v1.88.0',
     build = 'npm install --legacy-peer-deps && npx gulp vsDebugServerBundle && mv dist out'
   },
   {
-    'mxsdev/nvim-dap-vscode-js',
+    'mxsdev/nvim-dap-vscode-js', tag = 'v1.1.0',
     dependencies = {'mfussenegger/nvim-dap', 'microsoft/vscode-js-debug', 'stevearc/overseer.nvim' }
   },
   {
@@ -54,7 +54,7 @@ require('lazy').setup({
     dependencies = {'williamboman/mason.nvim', 'mfussenegger/nvim-dap', 'mxsdev/nvim-dap-vscode-js'}
   },
   {
-    'rcarriga/nvim-dap-ui',
+    'rcarriga/nvim-dap-ui', tag = 'v4.0.0',
     dependencies = {'mfussenegger/nvim-dap', 'nvim-neotest/nvim-nio'}
   },
   -- END DAP RELATED PLUGINS --


### PR DESCRIPTION
I  think I actually prefer this as an approach anyway, becuase with the manual download you get to specify the tag version of the adapter. I can't see how that can be done with mason, so I think this is probably preferable from a resilience point of view.